### PR TITLE
Upgrade Hydra to 1.1 (new stable version)

### DIFF
--- a/benchmarking_sbi/config/algorithm/nle.yaml
+++ b/benchmarking_sbi/config/algorithm/nle.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: NLE
 run: sbi.snle.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/npe.yaml
+++ b/benchmarking_sbi/config/algorithm/npe.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: NPE
 run: sbi.snpe.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/nre.yaml
+++ b/benchmarking_sbi/config/algorithm/nre.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: NRE
 run: sbi.snre.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/posterior.yaml
+++ b/benchmarking_sbi/config/algorithm/posterior.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: Posterior
 run: pytorch.baseline_posterior.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/prior.yaml
+++ b/benchmarking_sbi/config/algorithm/prior.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: Prior
 run: pytorch.baseline_prior.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/rej-abc.yaml
+++ b/benchmarking_sbi/config/algorithm/rej-abc.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: REJ-ABC
 run: sbi.mcabc.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/rf-abc.yaml
+++ b/benchmarking_sbi/config/algorithm/rf-abc.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: RF-ABC
 run: pyabcranger.abcrf.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/sl.yaml
+++ b/benchmarking_sbi/config/algorithm/sl.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: SL
 run: sbi.sl.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/smc-abc.yaml
+++ b/benchmarking_sbi/config/algorithm/smc-abc.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: SMC-ABC
 run: sbi.smcabc.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/snle.yaml
+++ b/benchmarking_sbi/config/algorithm/snle.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: SNLE
 run: sbi.snle.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/snpe.yaml
+++ b/benchmarking_sbi/config/algorithm/snpe.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: SNPE
 run: sbi.snpe.run
 device: cpu

--- a/benchmarking_sbi/config/algorithm/snre.yaml
+++ b/benchmarking_sbi/config/algorithm/snre.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: SNRE
 run: sbi.snre.run
 device: cpu

--- a/benchmarking_sbi/config/config.yaml
+++ b/benchmarking_sbi/config/config.yaml
@@ -3,6 +3,7 @@ compute_metrics: true
 
 # Hydra's overrides are used to change to different tasks and algorithms
 defaults:
+  - _self_
   - algorithm: prior
   - task: gaussian_linear
 

--- a/benchmarking_sbi/config/config.yaml
+++ b/benchmarking_sbi/config/config.yaml
@@ -3,9 +3,9 @@ compute_metrics: true
 
 # Hydra's overrides are used to change to different tasks and algorithms
 defaults:
-  - _self_
   - algorithm: prior
   - task: gaussian_linear
+  - _self_
 
 # Device to use, set on per-algorithm basis
 device: ${algorithm.device}

--- a/benchmarking_sbi/config/hydra/launcher/rq.yaml
+++ b/benchmarking_sbi/config/hydra/launcher/rq.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 enqueue:
   job_timeout: '1000d'
   ttl: '1000d'

--- a/benchmarking_sbi/config/task/bernoulli_glm.yaml
+++ b/benchmarking_sbi/config/task/bernoulli_glm.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: bernoulli_glm
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/bernoulli_glm_raw.yaml
+++ b/benchmarking_sbi/config/task/bernoulli_glm_raw.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: bernoulli_glm_raw
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/gaussian_linear.yaml
+++ b/benchmarking_sbi/config/task/gaussian_linear.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: gaussian_linear
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/gaussian_linear_uniform.yaml
+++ b/benchmarking_sbi/config/task/gaussian_linear_uniform.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: gaussian_linear_uniform
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/gaussian_mixture.yaml
+++ b/benchmarking_sbi/config/task/gaussian_mixture.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: gaussian_mixture
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/lotka_volterra.yaml
+++ b/benchmarking_sbi/config/task/lotka_volterra.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: lotka_volterra
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/sir.yaml
+++ b/benchmarking_sbi/config/task/sir.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: sir
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/slcp.yaml
+++ b/benchmarking_sbi/config/task/slcp.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: slcp
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/slcp_distractors.yaml
+++ b/benchmarking_sbi/config/task/slcp_distractors.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: slcp_distractors
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/config/task/two_moons.yaml
+++ b/benchmarking_sbi/config/task/two_moons.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: two_moons
 num_simulations: 1000
 num_observation: 1

--- a/benchmarking_sbi/requirements.txt
+++ b/benchmarking_sbi/requirements.txt
@@ -1,7 +1,7 @@
 ansible
 boto
 hiplot
-hydra-core==1.0.3
+hydra-core>=1.0.3
 hydra-joblib-launcher>=1.1.0
 hydra-rq-launcher>=1.0.1
 jupyter

--- a/benchmarking_sbi/requirements.txt
+++ b/benchmarking_sbi/requirements.txt
@@ -1,7 +1,7 @@
 ansible
 boto
 hiplot
-hydra-core>=1.0.3
+hydra-core>=1.1.1
 hydra-joblib-launcher>=1.1.0
 hydra-rq-launcher>=1.0.1
 jupyter

--- a/benchmarking_sbi/run.py
+++ b/benchmarking_sbi/run.py
@@ -11,7 +11,7 @@ import pandas as pd
 import sbibm
 import torch
 import yaml
-from pprint import pprint
+from pprint import pformat
 from omegaconf import DictConfig, OmegaConf
 from sbibm.utils.debug import pdb_hook
 from sbibm.utils.io import (
@@ -25,8 +25,7 @@ from sbibm.utils.io import (
 @hydra.main(config_path="config", config_name="config")
 def main(cfg: DictConfig) -> None:
     log = logging.getLogger(__name__)
-    log.info(pprint(cfg)
-             )
+    log.info(pformat(cfg))
     log.info(f"sbibm version: {sbibm.__version__}")
     log.info(f"Hostname: {socket.gethostname()}")
     if cfg.seed is None:

--- a/benchmarking_sbi/run.py
+++ b/benchmarking_sbi/run.py
@@ -11,7 +11,6 @@ import pandas as pd
 import sbibm
 import torch
 import yaml
-from pprint import pformat
 from omegaconf import DictConfig, OmegaConf
 from sbibm.utils.debug import pdb_hook
 from sbibm.utils.io import (
@@ -25,7 +24,7 @@ from sbibm.utils.io import (
 @hydra.main(config_path="config", config_name="config")
 def main(cfg: DictConfig) -> None:
     log = logging.getLogger(__name__)
-    log.info(pformat(cfg))
+    log.info(OmegaConf.to_yaml(cfg))
     log.info(f"sbibm version: {sbibm.__version__}")
     log.info(f"Hostname: {socket.gethostname()}")
     if cfg.seed is None:

--- a/benchmarking_sbi/run.py
+++ b/benchmarking_sbi/run.py
@@ -11,6 +11,7 @@ import pandas as pd
 import sbibm
 import torch
 import yaml
+from pprint import pprint
 from omegaconf import DictConfig, OmegaConf
 from sbibm.utils.debug import pdb_hook
 from sbibm.utils.io import (
@@ -24,7 +25,8 @@ from sbibm.utils.io import (
 @hydra.main(config_path="config", config_name="config")
 def main(cfg: DictConfig) -> None:
     log = logging.getLogger(__name__)
-    log.info(cfg.pretty())
+    log.info(pprint(cfg)
+             )
     log.info(f"sbibm version: {sbibm.__version__}")
     log.info(f"Hostname: {socket.gethostname()}")
     if cfg.seed is None:


### PR DESCRIPTION
as reported in #2, this PR supplies a quick fix for hydra incompatibilities.

for more lurking problems, this upgrade guide should be consulted
https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header
as there are still some warnings. 

@jan-matthis I am not so familiar with hydra. Will you have a look or should I try to get rid of the warnings?

btw, some `sbi` related errors prevail even with this fix:
```
$ python run.py task=gaussian_linear task.num_simulations=10000 algorithm=npe
#...
[2021-11-05 12:58:04,832][__main__][INFO] - Seed not specified, generating random seed for replicability
[2021-11-05 12:58:04,844][__main__][INFO] - Random seed: 1714620700
[2021-11-05 12:58:05,465][__main__][INFO] - Start run
[2021-11-05 12:58:05,465][sbibm.algorithms.sbi.snpe][INFO] - Running NPE
Running 10000 simulations.: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 10000/10000 [00:00<00:00, 27545.21it/s]
Neural network successfully converged after 176 epochs.

        -------------------------
        ||||| ROUND 1 STATS |||||:
        -------------------------
        Epochs trained: 176
        Best validation performance: 0.4112
        -------------------------
        
/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/sbi/inference/snpe/snpe_base.py:403: UserWarning: You set `sample_with_mcmc=False`. This is deprecated since `sbi v0.17.0` and will lead to an error in future versions. Please use `sample_with='mcmc'` instead.
  warn(
Drawing 10000 posterior samples: 100%|██████████████████████████████████████████████████████████████████████████████████████████████| 10000/10000 [00:00<00:00, 74628.96it/s]
Error executing job with overrides: ['task=gaussian_linear', 'task.num_simulations=10000', 'algorithm=npe']
Traceback (most recent call last):
  File "/home/steinbac/development/sbibm/results/benchmarking_sbi/run.py", line 251, in <module>
    cli()
  File "/home/steinbac/development/sbibm/results/benchmarking_sbi/run.py", line 247, in cli
    main()
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/main.py", line 48, in decorated_main
    _run_hydra(
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/_internal/utils.py", line 377, in _run_hydra
    run_and_report(
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/_internal/utils.py", line 214, in run_and_report
    raise ex
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/_internal/utils.py", line 211, in run_and_report
    return func()
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/_internal/utils.py", line 378, in <lambda>
    lambda: hydra.run(
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/_internal/hydra.py", line 111, in run
    _ = ret.return_value
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/core/utils.py", line 233, in return_value
    raise self._return_value
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/hydra/core/utils.py", line 160, in run_job
    ret.return_value = task_function(task_cfg)
  File "/home/steinbac/development/sbibm/results/benchmarking_sbi/run.py", line 66, in main
    outputs = run_fn(
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/sbibm/algorithms/sbi/snpe.py", line 129, in run
    log_prob_true_parameters = posterior.log_prob(true_parameters)
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/sbibm/utils/nflows.py", line 332, in log_prob
    log_probs += get_log_abs_det_jacobian(
  File "/home/steinbac/development/sbibm/results/sbibm-results-venv/lib64/python3.9/site-packages/sbibm/utils/torch.py", line 105, in get_log_abs_det_jacobian
    assert (
AssertionError: Mismatch in batch size, took sum over whole batch?
```

Closes #2 